### PR TITLE
feat: cache `get_all_data` lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .pytest_cache
 __pycache__/
 .vercel
+
+venv/

--- a/src/coursereg_history/api.py
+++ b/src/coursereg_history/api.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sqlite3
 from typing import Dict, List, Optional, Set, Union
@@ -259,6 +260,7 @@ def get_set_of_all_codes(year: Union[str, int],
     return codes
 
 
+@functools.lru_cache
 def get_all_data(year: Union[str, int],
                  semester: Union[str, int],
                  ug_gd: str) -> List[CourseData]:


### PR DESCRIPTION
Hello! Thanks for making this super useful app. It is definitely a time saver versus looking up the whole demand vs allocation reports and looking Ctrl+F-ing through them.

I noticed that loading a year could be improved by caching the results. Here are some performance results:

Measured network time:
```
First click of AY button (ie no cache timing): 1.38s-1.6s
<click another button>
Second click of same AY button: 104ms
More than 10x faster
```
On local dev, this is without caching, where I click one button, then another, then that button again (so 3 network requests):
![image](https://github.com/et-irl/courserekt/assets/28750310/b8692083-638b-4561-9f14-7cd005c2e75e)

This is with the caching, same steps:
![image](https://github.com/et-irl/courserekt/assets/28750310/12c8df46-61fe-4a78-ae02-8b8306b71627)

On production, this would mean after the first load, all data would be stored in memory. I don't know how tight your memory budget is but there are `3*2*2 = 12` total entries in the cache, so it should be okay. Do feel free to reject this PR though if your memory budget is really low!

Once caveat: if you ever rebuild the DB and need the updates to show, or change any of the internal functions, the cache will not update until you restart the application. To circumvent this, you could opt for a cache with a TTL.

